### PR TITLE
Bazel and scopes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,14 @@
+cc_library(
+  name = "mustache",
+  hdrs = ["mustache.h"],
+  srcs = ["mustache.cc"],
+  deps = ["@rapidjson//:rapidjson"],
+  copts = ["-Wno-sign-compare"],
+)
+
+cc_test(
+  name = "mustache-tests",
+  srcs = ["mustache-tests.cc"],
+  deps = [ "mustache", "@googletest//:gtest_main", "@rapidjson//:rapidjson" ],
+  data = glob([ "test-templates/*" ])
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,19 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+
+git_repository(
+    name = "googletest",
+    remote = "https://github.com/google/googletest",
+    tag = "release-1.8.1",
+)
+
+http_archive(
+        name = "rapidjson",
+        urls = [
+            "https://github.com/Tencent/rapidjson/archive/v1.1.0.zip",
+        ],
+        sha256 = "8e00c38829d6785a2dfb951bb87c6974fa07dfe488aa5b25deec4b8bc0f6a3ab",
+        strip_prefix = "rapidjson-1.1.0",
+        build_file = "@//bzl/rapidjson:BUILD",
+    )

--- a/bzl/rapidjson/BUILD
+++ b/bzl/rapidjson/BUILD
@@ -1,0 +1,14 @@
+# RapidJSON (rapidjson.org) library.
+# from https://github.com/Tencent/rapidjson
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # BSD/MIT.
+
+cc_library(
+    name = "rapidjson",
+    hdrs = glob(["include/rapidjson/**/*.h"]),
+    includes = ["include"],
+)

--- a/mustache-tests.cc
+++ b/mustache-tests.cc
@@ -111,8 +111,9 @@ TEST(RenderTemplate, WithAsPredicate) {
   TestTemplate("{{#a}}Hello {{.}}{{/a}}", "{ \"a\": 1}", "Hello 1");
   TestTemplate("{{#a}}Hello {{#b}}World{{/b}}{{/a}}", "{ \"a\": { \"b\": 2} }",
       "Hello World");
+  // 'b' gets resolved from the outer context
   TestTemplate("{{#a}}Hello {{#b}}World{{/b}}{{/a}}", "{ \"a\": 1, \"b\": 2 }",
-      "Hello ");
+      "Hello World");
   TestTemplate("{{#a}}Hello{{/a}}", "{ \"a\": true }", "Hello");
   TestTemplate("{{#a}}Hello{{/a}}", "{ \"a\": false }", "");
 }
@@ -138,6 +139,15 @@ TEST(RenderTemplate, ContextPreservingPredicate) {
   TestTemplate("{{?a}}{{b}}{{/a}}", "{ \"a\": { \"b\": 10} }", "");
   TestTemplate("{{?a}}{{b}}{{/a}}", "{ \"c\": { \"b\": 10}, \"b\": 20 }", "");
 }
+
+TEST(RenderTemplate, ResolveFromParentContext) {
+  TestTemplate("{{#a}}{{b}}{{/a}}", "{ \"a\": { \"b\": 10}, \"b\": 20 }", "10");
+  // 'c' should be resolved from parent.
+  TestTemplate("{{#a}}{{c}}{{/a}}", "{ \"a\": { }, \"c\": 20 }", "20");
+  // 'c.x' should be resolved from parent.
+  TestTemplate("{{#a}}{{c.x}}{{/a}}", "{ \"a\": { }, \"c\": { \"x\": 20 } }", "20");
+}
+
 
 TEST(RenderTemplate, IgnoredBlocks) {
   TestTemplate("Hello {{!ignoreme }} world", "{ \"ignoreme\": 1 }", "Hello  world");

--- a/mustache-tests.cc
+++ b/mustache-tests.cc
@@ -170,6 +170,10 @@ TEST(RenderTemplate, Partials) {
   TestTemplate("{{#outer}}{{>test-templates/partial.tmpl}}{{/outer}}",
       "{ \"outer\": [1,2,3] }", "Hello Hello Hello ");
 
+  // Variables in partials should recursively resolve up the context stack.
+  TestTemplate("{{#outer}}{{>test-templates/partial.tmpl}}{{/outer}}",
+      "{ \"outer\": [1,2,3], \"a\": \"foo\" }", "Hello fooHello fooHello foo");
+
   // Check that if a template is not found, <name>.mustache is also tried.
   TestTemplate("{{>test-templates/mst-template}}", "{ }", "Hello world");
 }


### PR DESCRIPTION
This adds some simple Bazel support (I was too lazy to install rapidjson and boost system-wide and this was a convenient way of building/testing).

This also fixes the resolution of tags from outer scopes while inside inner sections. I ran into this issue while trying to write some templates in Kudu.